### PR TITLE
Specify target for libc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ path = "src/lib/lib.rs"
 name = "runme"
 path = "src/bin/runme.rs"
 
-[dependencies]
+[target.'cfg(any(target_vendor = "apple", target_os = "freebsd"))'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
This is a simple change that will exclude the `libc` dependency if not needed.